### PR TITLE
表示選択ボタンが特定の解像度でかぶってしまう事象の修正

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
       <li><a href="#" onclick="viewlist()">ALL<strong>すべて表示</strong></a></li>
       <li><a href="#" onclick="viewlist('off')">OFF<strong>すべて消す</strong></a></li>
     </ul>
-    <ul class="navbar">
+    <ul class="navbar category">
       <li><a href="#" onclick="viewlist('game')">ゲーム<strong><img src="images/game.png"></strong></a></li>
       <li><a href="#" onclick="viewlist('manga')">漫画<strong><img src="images/manga.png"></strong></a></li>
       <li><a href="#" onclick="viewlist('anime')">アニメ<strong><img src="images/anime.png"></strong></a></li>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -2,3 +2,9 @@
 ---
 
 @import "{{ site.theme }}";
+
+@media screen and (max-width: 960px) {
+    .category{
+        top: 112px;
+    }
+}


### PR DESCRIPTION
拡大したときに、navbarが被ってしまいボタンが隠れてしまう事象の修正です。

テーマのスタイル仕様でscreen and (max-width: 960px)が適用の場合、なぜかnavbarの位置がabsolute指定になり、navbar同士が重なって片方が隠れるため、ボタンがなくなっているような挙動になっていました。(おそらくテーマ的にnavbarは一つだけの想定なのだと思います。)

片方の位置を強制的に再指定しました。
